### PR TITLE
Add subject prefixes to be removed

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -924,11 +924,57 @@ sub TicketSubjectClean {
         $Subject =~ s/\Q$TicketHook$TicketHookDivider\E\d+?\s*//g;
     }
 
-    # remove leading number with configured "RE:\s" or "RE[\d+]:\s" e. g. "RE: " or "RE[4]: "
-    $Subject =~ s/^($TicketSubjectRe(\[\d+\])?:\s)+//i;
+    # remove subject prefix(es) e. g. "RE: " or "RE[4]: "
+    $Subject =~ s/^(
+      ( Antw                                    # Dutch
+      | ATB                                     # Welsh
+      | ATB \.                                  # Latvian
+      | AW                                      # German
+      | Odp                                     # Polish
+      | R                                       # Italian
+      | ( Re | \Q$TicketSubjectRe\E ) ( \s* \[ \d+ \] )?
+      | REF                                     # French
+      | RES                                     # Portuguese
+      | Rif                                     # Italian
+      | SV                                      # Scandinavian
+      | V\x{00E1}                               # Magyar, "VA"
+      | VS                                      # Finnish
+      | YNT                                     # Turkish
+      | \x{05D4}\x{05E9}\x{05D1}                # Hebrew, "hashev"
+      | \x{0391}\x{03A0}                        # Greek, "AP"
+      | \x{03A3}\x{03A7}\x{0395}\x{03A4}        # Greek, "SChET"
+      | \x{041D}\x{0410}                        # some Slavic in Cyrillic, "na"
+      | \x{56DE}\x{590D}                        # Simp. Chinese, "huifu"
+      | \x{56DE}\x{8986}                        # Trad. Chinese, "huifu"
+      )
+      \s* [:\x{FF1A}] \s*
+    )+//ix;
 
-    # remove leading number with configured "Fwd:\s" or "Fwd[\d+]:\s" e. g. "Fwd: " or "Fwd[4]: "
-    $Subject =~ s/^($TicketSubjectFwd(\[\d+\])?:\s)+//i;
+    # remove subject prefix(es) e. g. "Fwd: " or "Fwd[4]: "
+    $Subject =~ s/^(
+      ( Doorst \.?                              # Dutch
+      | ENC                                     # Portuguese
+      | FS                                      # Icelandic
+      | ( Fwd | Fw | \Q$TicketSubjectFwd\E ) ( \s* \[ \d+ \] )?
+      | I                                       # Italian
+      | [\x{0130}I]LE?T                         # Turkish, "ILT", "ILET"
+      | P\x{0101}rs \.                          # Latvian, "PARS."
+      | PD                                      # Polish
+      | RV                                      # Spanish
+      | Tov\x{00E1}bb\x{00ED}t\x{00E1}s         # Magyar, "tovabbitas"
+      | TR                                      # French
+      | VB                                      # Swedish
+      | VL                                      # Finnish
+      | VS                                      # Norwegian
+      | WG                                      # German
+      | \x{03A0}\x{03A1}\x{0398}                # Greek, "PRTh"
+      | \x{8F49}\x{5BC4}                        # Trad. Chinese, "zhuanji"
+      | \x{8F49}\x{767C}                        # Trad. Chinese, "zhuanfa"
+      | \x{8F6C}\x{53D1}                        # Simp. Chinese, "zhuanfa"
+      | \x{8F6C}\x{5BC4}                        # Simp. Chinese, "zhuanji"
+      )
+      \s* [:\x{FF1A}] \s*
+    )+//ix;
 
     # trim white space at the beginning or end
     $Subject =~ s/(^\s+|\s+$)//;

--- a/scripts/test/Ticket/TicketSubject.t
+++ b/scripts/test/Ticket/TicketSubject.t
@@ -91,41 +91,53 @@ for my $TicketHook ( 'Ticket#', 'Call#', 'Ticket' ) {
         # TicketSubjectClean()
         $NewSubject = $TicketObject->TicketSubjectClean(
             TicketNumber => '2004040510440485',
-            Subject => 'Re[5]: [' . $TicketHook . ': 2004040510440485] Re: RE: WG: Some Subject',
+            Subject      => 'Re[5]: [' . $TicketHook . ': 2004040510440485] Re: RE: FYI: Some Subject',
         );
         $Self->Is(
             $NewSubject,
-            'WG: Some Subject',
+            'FYI: Some Subject',
             "TicketSubjectClean() Re[5]:",
         );
 
         # TicketSubjectClean()
         $NewSubject = $TicketObject->TicketSubjectClean(
             TicketNumber => '2004040510440485',
-            Subject => 'Re[5]: Re: RE: WG: Some Subject [' . $TicketHook . ': 2004040510440485]',
+            Subject      => 'Re[5]: Re: RE: FYI: Some Subject [' . $TicketHook . ': 2004040510440485]',
         );
         $Self->Is(
             $NewSubject,
-            'WG: Some Subject',
+            'FYI: Some Subject',
             "TicketSubjectClean() Re[5]",
         );
 
+        # TicketSubjectClean()
+        $NewSubject = $TicketObject->TicketSubjectClean(
+            TicketNumber => '2004040510440485',
+            Subject      => "SV: Antw: VS: REF : RE: RE[2]: AW: \x{0391}\x{03a0}: \x{0391}\x{03c0}: \x{03a3}\x{03a7}\x{0395}\x{03a4}: \x{03a3}\x{03c7}\x{03b5}\x{03c4}: \x{041d}\x{0430}: \x{043d}\x{0430}: V\x{00e1}: R: RIF: Atb.: RES: Odp: Ynt: ATB: \x{56de}\x{590d}: \x{56de}\x{8986}\x{ff1a}VS: Doorst: Doorst.: TR: WG: \x{03a0}\x{03a1}\x{0398}: Tov\x{00e1}bb\x{00ed}t\x{00e1}s: I: FS: P\x{0101}rs.: VB: ENC: \x{0130}LT: \x{0130}LET: ILT: ILET: \x{8f6c}\x{53d1}\x{ff1a}\x{8f49}\x{5bc4}: Re: Fwd: Some Subject [" . $TicketHook . ': 2004040510440485]',
+        );
+        $Self->Is(
+            $NewSubject,
+            'Re: Fwd: Some Subject',
+            "TicketSubjectClean() Multilingual",
+        );
+
+        # TicketSubjectBuild()
         # TicketSubjectBuild()
         $NewSubject = $TicketObject->TicketSubjectBuild(
             TicketNumber => '2004040510440485',
-            Subject      => "Re: [$TicketHook: 2004040510440485] Re: RE: WG: Some Subject",
+            Subject      => "Re: [$TicketHook: 2004040510440485] Re: RE: FYI: Some Subject",
         );
         if ( $TicketSubjectConfig eq 'Left' ) {
             $Self->Is(
                 $NewSubject,
-                'RE: [' . $TicketHook . '2004040510440485] WG: Some Subject',
+                'RE: [' . $TicketHook . '2004040510440485] FYI: Some Subject',
                 "TicketSubjectBuild() $TicketSubjectConfig ($NewSubject)",
             );
         }
         else {
             $Self->Is(
                 $NewSubject,
-                'RE: WG: Some Subject [' . $TicketHook . '2004040510440485]',
+                'RE: FYI: Some Subject [' . $TicketHook . '2004040510440485]',
                 "TicketSubjectBuild() $TicketSubjectConfig ($NewSubject)",
             );
         }
@@ -167,7 +179,7 @@ for my $TicketHook ( 'Ticket#', 'Call#', 'Ticket' ) {
             );
         }
 
-        # check Ticket::SubjectRe with "Antwort"
+        # check Ticket::SubjectRe with empty value
         $ConfigObject->Set(
             Key   => 'Ticket::SubjectRe',
             Value => '',
@@ -180,7 +192,7 @@ for my $TicketHook ( 'Ticket#', 'Call#', 'Ticket' ) {
         );
         $Self->Is(
             $NewSubject,
-            'RE: Antwort: Antwort: Some Subject2',
+            'Antwort: Antwort: Some Subject2',
             "TicketSubjectClean() Re: Antwort:",
         );
 
@@ -192,14 +204,14 @@ for my $TicketHook ( 'Ticket#', 'Call#', 'Ticket' ) {
         if ( $TicketSubjectConfig eq 'Left' ) {
             $Self->Is(
                 $NewSubject,
-                '[' . $TicketHook . '2004040510440485] Re: Re: Antwort: Some Subject2',
+                '[' . $TicketHook . '2004040510440485] Antwort: Some Subject2',
                 "TicketSubjectBuild() $TicketSubjectConfig ($NewSubject)",
             );
         }
         else {
             $Self->Is(
                 $NewSubject,
-                'Re: Re: Antwort: Some Subject2 [' . $TicketHook . '2004040510440485]',
+                'Antwort: Some Subject2 [' . $TicketHook . '2004040510440485]',
                 "TicketSubjectBuild() $TicketSubjectConfig ($NewSubject)",
             );
         }
@@ -219,39 +231,39 @@ for my $TicketHook ( 'Ticket#', 'Call#', 'Ticket' ) {
         # TicketSubjectBuild()
         $NewSubject = $TicketObject->TicketSubjectBuild(
             TicketNumber => '2004040510440485',
-            Subject      => "Re: [$TicketHook: 2004040510440485] Re: RE: WG: Some Subject",
+            Subject      => "Re: [$TicketHook: 2004040510440485] Re: RE: FYI: Some Subject",
             Action       => 'Forward',
         );
         if ( $TicketSubjectConfig eq 'Left' ) {
             $Self->Is(
                 $NewSubject,
-                'FWD: [' . $TicketHook . '2004040510440485] WG: Some Subject',
+                'FWD: [' . $TicketHook . '2004040510440485] FYI: Some Subject',
                 "TicketSubjectBuild() $TicketSubjectConfig ($NewSubject)",
             );
         }
         else {
             $Self->Is(
                 $NewSubject,
-                'FWD: WG: Some Subject [' . $TicketHook . '2004040510440485]',
+                'FWD: FYI: Some Subject [' . $TicketHook . '2004040510440485]',
                 "TicketSubjectBuild() $TicketSubjectConfig ($NewSubject)",
             );
         }
 
-        # check Ticket::SubjectFwd with "WG"
+        # check Ticket::SubjectFwd with "Forwarded"
         $ConfigObject->Set(
             Key   => 'Ticket::SubjectFwd',
-            Value => 'WG',
+            Value => 'Forwarded',
         );
         $NewSubject = $TicketObject->TicketSubjectClean(
             TicketNumber => '2004040510440485',
             Subject      => 'Antwort: ['
                 . $TicketHook
-                . ': 2004040510440485] WG: Fwd: Some Subject2',
+                . ': 2004040510440485] Forwarded: Fwd: Some Subject2',
             Action => 'Forward',
         );
         $Self->Is(
             $NewSubject,
-            'Antwort: WG: Fwd: Some Subject2',
+            'Antwort: Forwarded: Fwd: Some Subject2',
             "TicketSubjectClean() Antwort:",
         );
     }


### PR DESCRIPTION
## Description

In this PR, I add variants in several languages of the prefixes like `RE:` / `Fwd:` that should be scraped off the subject. That is, those listed in [1][2][3] that I could actually find on the Internet, or some I have discovered independently.

In addition, several other improvements have been made: In some languages, a space is also placed before a colon [4]; a fullwidth colon is sometimes used after the prefix in Chinese ideographs; the space is not always placed after a colon. 

## Question

I think this PR could be applied to Znuny and OTOBO. Should I submit separate PRs for each?

## References

[1] Wikipedia: "[List of email subject abbreviations#Abbreviations in other languages](https://en.wikipedia.org/wiki/List_of_email_subject_abbreviations#Abbreviations_in_other_languages)".
[2] GNU Mailman 2.1: [Mailman/Handleres/CookHeaders.py](https://bazaar.launchpad.net/~mailman-coders/mailman/2.1/view/head:/Mailman/Handlers/CookHeaders.py#L424).
[3] Sympa 6.2: [Sympa/Regexps.pm](https://github.com/sympa-community/sympa/blob/6.2.70/src/lib/Sympa/Regexps.pm#L79-L81).
[4] [Bug \#893290](https://bugs.launchpad.net/mailman/+bug/893290).
